### PR TITLE
3.5: Основы фреймворка

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,19 +1,17 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
 }
 
-class MyApp extends StatelessWidget {
+class App extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Flutter Demo',
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
-        visualDensity: VisualDensity.adaptivePlatformDensity,
+      title: 'Модуль 3 задача 5',
+      home: MySecondWidget(
+        title: 'MyFirstWidget',
       ),
-      home: MyFirstWidget(title: 'Flutter Demo'),
     );
   }
 }
@@ -22,15 +20,17 @@ class MyFirstWidget extends StatelessWidget {
   const MyFirstWidget({Key key, this.title}) : super(key: key);
   final title;
 
+  // void getContext() => print(context.runtimeType); // ошибка Undefined name 'context'
+
   @override
   Widget build(BuildContext context) {
     int _counter = 0;
     _counter++;
-    print(_counter);
+    print('счётчик: $_counter');
 
     return Container(
       child: Center(
-        child: Text('Hello! - $_counter'),
+        child: Text('Hello'),
       ),
     );
   }
@@ -45,22 +45,25 @@ class MySecondWidget extends StatefulWidget {
 }
 
 class _MySecondWidgetState extends State<MySecondWidget> {
-int _counter = 0;
+  int _counter = 0;
 
-void _incrementCounter() {
+  void _incrementCounter() {
     setState(() {
       _counter++;
     });
   }
 
+  void getContext() => print('контекст: ${context.runtimeType}');
+
   @override
   Widget build(BuildContext context) {
     _incrementCounter();
-    print(_counter);
+    print('счётчик: $_counter');
+    getContext();
 
     return Container(
       child: Center(
-        child: Text('Hello! - $_counter'),
+        child: Text('Hello!'),
       ),
     );
   }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:places/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(MyApp());
+    await tester.pumpWidget(App());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
1. Переименуйте файл main.dart в start.dart. Запустите проект. Почему результат именно таков?

_Проект запустился, так как единая точка входа в программу находится в функции main. По умолчанию стартовый файл должен называться main.dart_

4. В методе build() верните MaterialApp в поле home поставьте Stateless виджет из предыдущего домашнего задания(см. урок про виджеты). Рассмотрите его параметры. Задайте поле title. Запустите на Android. Где отобразится значение этого поля?

_Title в андроид отображается как подпись к последним использованным приложениям, аналог title в браузере._

5. Перейдем к рассмотрению контекста. В вашем Stateless виджет создайте функцию, которая будет возвращать context.runtimeType. Функция должна быть без аргументов. Получится ли ее реализовать в данном виджете?

_Не получится
Undefined name 'context'_

6. Проделайте предыдущий пункт в рамках Stateful. В чем разница?

_контекст: StatefulElement_