### PR TITLE
4.4: Использование виджетов с установкой размеров

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:places/ui/screen/sight_details.dart';
-
-import 'mocks.dart';
+import 'package:places/ui/screen/sight_list_screen.dart';
 
 void main() {
   runApp(App());
@@ -13,8 +11,8 @@ class App extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Places',
-      // home: SightListScreen(), // список мест
-      home: SightDetails(card: mocks[0]), // подробности -описание места
+      home: SightListScreen(), // список мест
+      // home: SightDetails(card: mocks[0]), // подробности -описание места
     );
   }
 }

--- a/lib/ui/screen/sight_card.dart
+++ b/lib/ui/screen/sight_card.dart
@@ -9,61 +9,71 @@ class SightCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ClipRRect(
-      borderRadius: BorderRadius.circular(12),
-      child: Container(
-        color: colorBackground,
-        child: Column(
-          children: [
-            Stack(
-              children: [
-                Container(
-                  color: Colors.lightBlue[400],
-                  width: double.infinity,
-                  height: 96,
-                ),
-                Positioned(
-                  top: 16,
-                  left: 16,
-                  right: 16,
-                  child: Row(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                        '${card.type}',
-                        style: textStyleSmall14BoldWhite,
-                      ),
-                      Icon(
-                        Icons.favorite_border,
-                        color: Colors.white,
-                        size: 24,
-                      ),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-            Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
+    return AspectRatio(
+      aspectRatio: 3 / 2,
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(12),
+        child: Container(
+          color: colorBackground,
+          child: Column(
+            children: [
+              Stack(
                 children: [
-                  Text(
-                    '${card.nameSights}',
-                    style: textStyleText16Secondary,
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 2,
+                  Container(
+                    color: Colors.lightBlue[400],
+                    width: double.infinity,
+                    height: 96,
                   ),
-                  Text(
-                    '${card.details}',
-                    style: textStyleSmall14Secondary2,
-                    overflow: TextOverflow.ellipsis,
-                    maxLines: 1,
+                  Positioned(
+                    top: 16,
+                    left: 16,
+                    right: 16,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          '${card.type}',
+                          style: textStyleSmall14BoldWhite,
+                        ),
+                        Icon(
+                          Icons.favorite_border,
+                          color: Colors.white,
+                          size: 24,
+                        ),
+                      ],
+                    ),
                   ),
                 ],
               ),
-            )
-          ],
+              SizedBox(
+                //❓❓❓это добавить по заданию, а зачем если падингом можно
+                height: 16,
+              ),
+              Padding(
+                padding: const EdgeInsets.only(left: 16, right: 16, bottom: 16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '${card.nameSights}',
+                      style: textStyleText16Secondary,
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 2,
+                    ),
+                    SizedBox(
+                      height: 2,
+                    ),
+                    Text(
+                      '${card.details}',
+                      style: textStyleSmall14Secondary2,
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 1,
+                    ),
+                  ],
+                ),
+              )
+            ],
+          ),
         ),
       ),
     );

--- a/lib/ui/screen/sight_list_screen.dart
+++ b/lib/ui/screen/sight_list_screen.dart
@@ -18,14 +18,19 @@ class _SightListScreenState extends State<SightListScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: colorWhiteWhite,
-      appBar: AppBar(
-        title: Padding(
-          padding: const EdgeInsets.only(left: 16, top: 40, right: 16),
-          child: appBarTitle,
+      appBar: PreferredSize(
+        preferredSize: Size.fromHeight(152),
+        child: AppBar(
+          flexibleSpace: Align(
+            alignment: Alignment.bottomLeft,
+            child: Container(
+              margin: EdgeInsets.only(left: 16, right: 16, bottom: 16),
+              child: appBarTitle,
+            ),
+          ),
+          backgroundColor: Colors.transparent,
+          elevation: 0,
         ),
-        toolbarHeight: 112.0,
-        backgroundColor: Colors.transparent,
-        elevation: 0,
       ),
       body: SingleChildScrollView(
         child: Padding(
@@ -41,7 +46,6 @@ class _SightListScreenState extends State<SightListScreen> {
 
 List<Widget> buildCard(List<Sight> data) {
   var cards = <Widget>[];
-  cards.add(SizedBox(height: 16));
 
   for (var item in data) {
     cards.add(SightCard(card: item));

--- a/lib/ui/screen/sight_list_screen_constant.dart
+++ b/lib/ui/screen/sight_list_screen_constant.dart
@@ -4,5 +4,4 @@ import 'package:places/constant.dart';
 const appBarTitle = Text(
   'Список\nинтересных мест',
   style: textStyleLargeTitle32Secondary,
-  textAlign: TextAlign.left,
 );


### PR DESCRIPTION
1. В виджете SightCard используйте ConstrainedBox, чтобы ограничить размер текста  по ширине до половины размера карточки. Посмотрите на результат. Почему размер текста поменялся? После выполнения,  отрегулируйте размер текста согласно дизайну.

Размер текста меняется, так как блоку с текстом приходят ограничения от его родителя. ConstrainedBox задаёт диапазон размеров в котором может находиться ребёнок.Если размеры ребенка больше ограничений, то ребенок получает максимальный размер из ограничений, если меньше - то минимальный размер из ограничений, если в диапазоне - то ребенок будет такого размера как он хочет.

По-поводу "ограничить размер текста  по ширине до половины размера карточки" - я задавала размер вручную, если имелось ввиду написать функцию для автоматического вычисления точных размеров или типа того, то не пришло в голову как это можно сделать. Самое простое поделить пространство на одинаковые части это завернуть каждого ребенка в Expanded с одинаковым flex параметром.

2. Добавьте отступ между между фотографиями и описанием с помощью SizedBox

добавила

3. AspectRatio используйте, чтобы привести виджеты SightCard в соотношение 3/2.

Карточки увеличились в размерах

![Снимок экрана 2020-12-09 в 22 14 43](https://user-images.githubusercontent.com/39735343/101677462-a8a27f00-3a6d-11eb-8da2-01b23d3e7ea9.png)

4. Переверстать AppBar через наследника PreferredSizeWidget

оно? 👀🤓